### PR TITLE
feat(openclaw-sandbox): add openssh-client

### DIFF
--- a/apps/openclaw-sandbox/Dockerfile
+++ b/apps/openclaw-sandbox/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates \
       procps \
       unzip \
+      openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # uv (includes python3)

--- a/apps/openclaw-sandbox/tests.yaml
+++ b/apps/openclaw-sandbox/tests.yaml
@@ -50,3 +50,8 @@ commandTests:
     command: "which"
     args: ["unzip"]
     exitCode: 0
+
+  - name: "ssh exists"
+    command: "which"
+    args: ["ssh"]
+    exitCode: 0


### PR DESCRIPTION
Adds `openssh-client` to the sandbox image so the agent can SSH to mac.internal for managing local MLX models, running builds, and monitoring services.

One-line change to the apt-get install list.