### PR TITLE
fix(moltis-sandbox): move glab binary to /usr/local/bin

### DIFF
--- a/apps/moltis-sandbox/Dockerfile
+++ b/apps/moltis-sandbox/Dockerfile
@@ -30,7 +30,8 @@ RUN curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${G
 
 # glab (GitLab CLI)
 RUN curl -sL "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" | \
-      tar xz --strip-components=1 -C /usr/local
+      tar xz --strip-components=1 -C /usr/local && \
+    mv /usr/local/glab /usr/local/bin/glab
 
 # 1password-cli
 RUN curl -sS "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_VERSION}/op_linux_amd64_v${OP_VERSION}.zip" \


### PR DESCRIPTION
The glab tarball extracts as `bin/glab`, so `--strip-components=1 -C /usr/local` lands it at `/usr/local/glab` instead of `/usr/local/bin/glab`, making it invisible to PATH.

This adds a `mv` step to put it in the right place.