### PR TITLE
feat(openclaw-sandbox): add openssh-server for SSH sandbox backend

### DIFF
--- a/apps/openclaw-sandbox/Dockerfile
+++ b/apps/openclaw-sandbox/Dockerfile
@@ -13,7 +13,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       procps \
       unzip \
       openssh-client \
+      openssh-server \
     && rm -rf /var/lib/apt/lists/*
+
+# sshd setup for SSH sandbox backend
+RUN mkdir -p /run/sshd && \
+    sed -i "s/#PermitRootLogin.*/PermitRootLogin no/" /etc/ssh/sshd_config && \
+    sed -i "s/#PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config && \
+    sed -i "s/#PubkeyAuthentication.*/PubkeyAuthentication yes/" /etc/ssh/sshd_config && \
+    echo "AuthorizedKeysFile /etc/ssh/authorized_keys/%u" >> /etc/ssh/sshd_config
 
 # uv (includes python3)
 RUN curl -fsSL "https://astral.sh/uv/${UV_VERSION}/install.sh" | \


### PR DESCRIPTION
Add sshd for SSH sandbox backend support. Bump to 3.0.0.