### PR TITLE
sandbox: restore openssh-client + add iputils-ping

### DIFF
--- a/apps/openclaw-sandbox/Dockerfile
+++ b/apps/openclaw-sandbox/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       jq \
       ca-certificates \
       procps \
+      openssh-client \
+      iputils-ping \
       unzip \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
openssh-client was removed during the SSH→DinD sandbox revert. It's needed for reaching mac.internal and work.internal via Tailscale (Kiro digest, OpenCode access, kubectl via SSH hop).

iputils-ping added for basic network debugging — the sandbox currently has no connectivity diagnostic tools at all.