### PR TITLE
feat(presidio-analyzer): add slim sm/md spaCy model flavors

### DIFF
--- a/apps/presidio-analyzer-md/Dockerfile
+++ b/apps/presidio-analyzer-md/Dockerfile
@@ -1,0 +1,26 @@
+# Slim Presidio Analyzer: bundles the medium spaCy model instead of en_core_web_lg
+# to cut resident memory on memory-tight clusters. RAM is driven by which model
+# LOADS, so we ship exactly one model (lg removed) per image.
+ARG VERSION=2.2.362
+FROM mcr.microsoft.com/presidio-analyzer:${VERSION}
+
+# Which spaCy model to bundle. This image is the "md" flavor.
+ARG SPACY_MODEL=en_core_web_md
+
+# Need root to write into site-packages and the conf file.
+USER root
+
+RUN python -m spacy download "${SPACY_MODEL}" \
+  # Drop the stock large model to save disk + RAM (try both name spellings).
+  && (pip uninstall -y en_core_web_lg || true) \
+  && (pip uninstall -y en-core-web-lg || true) \
+  # Point the NLP engine at the bundled model, keeping the rest of the conf intact.
+  && sed -i -E "s/^([[:space:]]*model_name:[[:space:]]*).*/\1${SPACY_MODEL}/" \
+    /app/presidio_analyzer/conf/default.yaml
+
+# Revert to the original non-root user.
+USER 1001
+
+EXPOSE 3000
+
+# Entrypoint/CMD inherited from the upstream image (./entrypoint.sh, gunicorn :3000).

--- a/apps/presidio-analyzer-md/docker-bake.hcl
+++ b/apps/presidio-analyzer-md/docker-bake.hcl
@@ -1,0 +1,46 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "presidio-analyzer-md"
+}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=mcr.microsoft.com/presidio-analyzer
+  default = "2.2.362"
+}
+
+variable "SPACY_MODEL" {
+  default = "en_core_web_md"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/microsoft/presidio"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  args = {
+    VERSION     = "${VERSION}"
+    SPACY_MODEL = "${SPACY_MODEL}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output   = ["type=docker"]
+  tags     = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/presidio-analyzer-md/tests.yaml
+++ b/apps/presidio-analyzer-md/tests.yaml
@@ -1,0 +1,27 @@
+schemaVersion: 2.0.0
+
+commandTests:
+  - name: "bundled spaCy model imports"
+    command: "python"
+    args: ["-c", "import en_core_web_md"]
+    exitCode: 0
+
+  - name: "stock en_core_web_lg is removed"
+    command: "python"
+    args: ["-c", "import en_core_web_lg"]
+    exitCode: 1
+
+  - name: "nlp conf points at the bundled model"
+    command: "grep"
+    args: ["-q", "model_name: en_core_web_md", "/app/presidio_analyzer/conf/default.yaml"]
+    exitCode: 0
+
+fileExistenceTests:
+  - name: "presidio nlp conf exists"
+    path: "/app/presidio_analyzer/conf/default.yaml"
+    shouldExist: true
+
+metadataTest:
+  exposedPorts: ["3000"]
+  user: "1001"
+  workdir: "/app"

--- a/apps/presidio-analyzer-sm/Dockerfile
+++ b/apps/presidio-analyzer-sm/Dockerfile
@@ -1,0 +1,26 @@
+# Slim Presidio Analyzer: bundles the small spaCy model instead of en_core_web_lg
+# to cut resident memory on memory-tight clusters. RAM is driven by which model
+# LOADS, so we ship exactly one model (lg removed) per image.
+ARG VERSION=2.2.362
+FROM mcr.microsoft.com/presidio-analyzer:${VERSION}
+
+# Which spaCy model to bundle. This image is the "sm" flavor.
+ARG SPACY_MODEL=en_core_web_sm
+
+# Need root to write into site-packages and the conf file.
+USER root
+
+RUN python -m spacy download "${SPACY_MODEL}" \
+  # Drop the stock large model to save disk + RAM (try both name spellings).
+  && (pip uninstall -y en_core_web_lg || true) \
+  && (pip uninstall -y en-core-web-lg || true) \
+  # Point the NLP engine at the bundled model, keeping the rest of the conf intact.
+  && sed -i -E "s/^([[:space:]]*model_name:[[:space:]]*).*/\1${SPACY_MODEL}/" \
+    /app/presidio_analyzer/conf/default.yaml
+
+# Revert to the original non-root user.
+USER 1001
+
+EXPOSE 3000
+
+# Entrypoint/CMD inherited from the upstream image (./entrypoint.sh, gunicorn :3000).

--- a/apps/presidio-analyzer-sm/docker-bake.hcl
+++ b/apps/presidio-analyzer-sm/docker-bake.hcl
@@ -1,0 +1,46 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "presidio-analyzer-sm"
+}
+
+variable "VERSION" {
+  // renovate: datasource=docker depName=mcr.microsoft.com/presidio-analyzer
+  default = "2.2.362"
+}
+
+variable "SPACY_MODEL" {
+  default = "en_core_web_sm"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/microsoft/presidio"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  args = {
+    VERSION     = "${VERSION}"
+    SPACY_MODEL = "${SPACY_MODEL}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output   = ["type=docker"]
+  tags     = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/presidio-analyzer-sm/tests.yaml
+++ b/apps/presidio-analyzer-sm/tests.yaml
@@ -1,0 +1,27 @@
+schemaVersion: 2.0.0
+
+commandTests:
+  - name: "bundled spaCy model imports"
+    command: "python"
+    args: ["-c", "import en_core_web_sm"]
+    exitCode: 0
+
+  - name: "stock en_core_web_lg is removed"
+    command: "python"
+    args: ["-c", "import en_core_web_lg"]
+    exitCode: 1
+
+  - name: "nlp conf points at the bundled model"
+    command: "grep"
+    args: ["-q", "model_name: en_core_web_sm", "/app/presidio_analyzer/conf/default.yaml"]
+    exitCode: 0
+
+fileExistenceTests:
+  - name: "presidio nlp conf exists"
+    path: "/app/presidio_analyzer/conf/default.yaml"
+    shouldExist: true
+
+metadataTest:
+  exposedPorts: ["3000"]
+  user: "1001"
+  workdir: "/app"


### PR DESCRIPTION
## Why

Cut Presidio Analyzer resident memory on a memory-tight Kubernetes cluster. The
stock `mcr.microsoft.com/presidio-analyzer` image loads `en_core_web_lg`, which
needs ~1Gi+ resident. Resident memory is driven by *which spaCy model loads at
runtime*, so these images ship a single smaller model and rewrite the NLP conf
to load it:

- `ghcr.io/solanyn/presidio-analyzer-md` → `en_core_web_md` (~400–500Mi resident)
- `ghcr.io/solanyn/presidio-analyzer-sm` → `en_core_web_sm` (~250–300Mi resident)

Reduced NER recall from sm/md is an acceptable trade-off here: the regex guard in
the upstream agentgateway consumer already covers structured PII, so the smaller
model only affects free-text named-entity recall.

## What

Two apps, one model each, built `FROM` the upstream image:

- `python -m spacy download <model>` to bundle the chosen model
- rewrite `/app/presidio_analyzer/conf/default.yaml` so `model_name` is the bundled
  model (rest of the conf untouched)
- `pip uninstall -y en_core_web_lg` as a hard guarantee lg can't be loaded
- upstream entrypoint/CMD (`./entrypoint.sh`, gunicorn `:3000`), user `1001`, and
  `EXPOSE 3000` left unchanged

Pinned to upstream `2.2.362` with a renovate datasource comment. Multi-arch
`image-all` (linux/amd64, linux/arm64).

### Deploy-time selection

Pick the size/accuracy trade-off by **image name** (`-sm` vs `-md`), each carrying
the upstream version tags. Two separate app dirs publish to two distinct image
names with zero changes to the shared `app-builder` workflow, which keys on the
app directory name and derives tags from `VERSION` via `docker/metadata-action`.
Per-flavor *tag suffixes* on a single image name would have required rewriting the
shared plan/build/release/attest jobs, so distinct image names are the cleaner fit.

## Note on image size

These slim images are **not** smaller on disk (sm 1.58GB, md 1.65GB vs stock
1.56GB). `en_core_web_lg` lives in an inherited base layer; `pip uninstall` in a
child layer only writes whiteout metadata and can't reclaim parent-layer space,
and we additionally add the new model. The win is **resident memory**, not disk —
only the small/medium model is loaded at runtime.

## Testing

Built and structure-tested both flavors locally via
`task local-build-presidio-analyzer-sm` and `task local-build-presidio-analyzer-md`.
Both pass 5/5: bundled model imports, `en_core_web_lg` import fails, conf points at
the bundled model, conf file exists, exposed port 3000 / user 1001 / workdir /app.